### PR TITLE
add KID implementation to fid_score.py

### DIFF
--- a/compare_gan/src/fid_score.py
+++ b/compare_gan/src/fid_score.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 from __future__ import division
 import functools
+import math
 import numpy as np
 import tensorflow as tf
 
@@ -25,9 +26,9 @@ logging = tf.logging
 tfgan_eval = tf.contrib.gan.eval
 
 
-
 def get_fid_function(eval_image_tensor, gen_image_tensor, num_gen_images,
-                     num_eval_images, image_range, inception_graph):
+                     num_eval_images, image_range, inception_graph,
+                     include_kid=False, kid_max_batch_size=1024):
   """Get a fn returning the FID between distributions defined by two tensors.
 
   Wraps session.run calls to generate num_eval_images images from both
@@ -110,6 +111,15 @@ def get_fid_function(eval_image_tensor, gen_image_tensor, num_gen_images,
   with tf.control_dependencies([update_fid_op]):
     fid_tensor = tf.identity(fid_tensor)
 
+  if include_kid:
+    kid_variable = tf.Variable(0.0, name="last_computed_KID", trainable=False)
+    tf.summary.scalar("last_computed_KID", kid_variable)
+    kid_tensor = kid(feed_eval_features, feed_gen_features,
+                     max_batch_size=kid_max_batch_size)
+    update_kid_op = kid_variable.assign(kid_tensor)
+    with tf.control_dependencies([update_kid_op]):
+      kid_tensor = tf.identity(kid_tensor)
+
   # Define a function which wraps some session.run calls to generate a large
   # number of images and compute FID on them.
   def eval_fn(session):
@@ -134,7 +144,17 @@ def get_fid_function(eval_image_tensor, gen_image_tensor, num_gen_images,
         feed_gen_features: gen_features_np})
 
     logging.info("Computed FID: %f", fid_result)
-    return fid_result
+
+    if include_kid:
+      logging.info("Computing KID with generated images...")
+      kid_result = session.run(kid_tensor, feed_dict={
+        feed_eval_features: eval_features_np,
+        feed_gen_features: gen_features_np})
+      logging.info("Computed KID: %f", kid_result)
+
+      return fid_result, kid_result
+    else:
+      return fid_result
 
   return eval_fn
 
@@ -188,3 +208,86 @@ def inception_score_fn(images, num_batches, inception_graph):
       images, num_batches=num_batches,
       classifier_fn=functools.partial(run_inception,
                                       inception_graph=inception_graph))
+
+
+def kid(real_activations, generated_activations, max_batch_size=1024,
+        dtype=None, return_stderr=False):
+  """Unbiased estimator of the Kernel Inception Distance, as
+  defined by https://arxiv.org/abs/1801.01401.
+
+  If return_stderr, also returns an estimate of the standard error, i.e. the
+  standard deviation of the KID estimator. Returns nan if the number
+  of batches is too small (< 5); for more reliable estimates, one could use
+  the asymptotic variance estimate given in https://arxiv.org/abs/1611.04488.
+
+  Uses a block estimator, as in https://arxiv.org/abs/1307.1954, with blocks
+  no larger than max_batch_size. This is slightly different than the authors'
+  provided code, but is also unbiased (and provides more-valid a variance
+  estimate).
+
+  NOTE: the blocking code assumes that real_activations and
+  generated_activations are in random order. If real_activations is sorted
+  in a meaningful order, the estimator will be biased.
+  """
+  real_activations.get_shape().assert_has_rank(2)
+  generated_activations.get_shape().assert_has_rank(2)
+
+  # need to know dimension for the kernel, and batch size to split things
+  real_activations.get_shape().assert_is_fully_defined()
+  generated_activations.get_shape().assert_is_fully_defined()
+
+  n_real, dim = real_activations.get_shape().as_list()
+  n_gen, dim2 = generated_activations.get_shape().as_list()
+  assert dim2 == dim
+
+  # tfgan forces doubles for FID, but I don't think we need that here
+  if dtype is None:
+    dtype = real_activations.dtype
+    assert generated_activations.dtype == dtype
+  else:
+    real_activations = tf.cast(real_activations, dtype)
+    generated_activations = tf.cast(generated_activations, dtype)
+
+  # split into largest approximately-equally-sized blocks
+  n_bins = math.ceil(max(n_real, n_gen) / max_batch_size)
+  bins_r = np.full(n_bins, math.ceil(n_real / n_bins))
+  bins_g = np.full(n_bins, math.ceil(n_gen / n_bins))
+  bins_r[:(n_bins * bins_r[0]) - n_real] -= 1
+  bins_g[:(n_bins * bins_r[0]) - n_gen] -= 1
+  assert bins_r.min() >= 2
+  assert bins_g.min() >= 2
+
+  inds_r = tf.constant(np.r_[0, np.cumsum(bins_r)])
+  inds_g = tf.constant(np.r_[0, np.cumsum(bins_g)])
+
+  dim_ = tf.cast(dim, dtype)
+  def get_kid_batch(i):
+    r_s = inds_r[i]
+    r_e = inds_r[i + 1]
+    R = real_activations[r_s:r_e]
+    m = tf.cast(r_e - r_s, dtype)
+
+    g_s = inds_g[i]
+    g_e = inds_g[i + 1]
+    G = generated_activations[g_s:g_e]
+    n = tf.cast(r_e - r_s, dtype)
+
+    # Could probably do this a bit faster...
+    K_RR = (tf.matmul(R, R, transpose_b=True) / dim_ + 1) ** 3
+    K_RG = (tf.matmul(R, G, transpose_b=True) / dim_ + 1) ** 3
+    K_GG = (tf.matmul(G, G, transpose_b=True) / dim_ + 1) ** 3
+    return (
+      -2 * tf.reduce_mean(K_RG)
+      + (tf.reduce_sum(K_RR) - tf.trace(K_RR)) / (m * (m - 1))
+      + (tf.reduce_sum(K_GG) - tf.trace(K_GG)) / (n * (n - 1)))
+
+  ests = tf.map_fn(get_kid_batch, np.arange(n_bins), dtype=dtype,
+                   back_prop=False)
+
+  if return_stderr:
+    if n_bins < 5:
+      return tf.reduce_mean(ests), np.nan
+    mn, var = tf.nn.moments(ests, [0])
+    return mn, tf.sqrt(var / n_bins)
+  else:
+    return tf.reduce_mean(ests)


### PR DESCRIPTION
As discussed elsewhere: add an implementation of KID. Compared to [our implementation](https://github.com/MichaelArbel/Scaled-MMD-GAN/blob/master/gan/compute_scores.py), this one:
- Is in tensorflow instead of in numpy.
- Is a slightly different estimator. The other one takes the mean of 50 samples of the input of size 1000; this one takes the mean of however many samples of size no more than 1024 it takes to use each input once. Both are unbiased; this variant is maybe "more" normally-distributed, and gives a simple estimate of the variance if the number of resulting blocks is largeish.

I kind of hacked it into `get_fid_function` (off by default) to avoid having to featurize the images twice, because that's definitely the slowest part of either estimator and is a waste of time.

My impression is that you can get reliable estimates with fewer samples than FID, which is the big win – though because of FID's bias it's hard to really evaluate what "reliable" means. For 50k samples, blocks of size 1k, and 2048-dimensional activations, the MMD estimate also seems to be faster than the FID estimate that needs an expensive matrix square root, though that difference is smaller and less important.